### PR TITLE
Add minimum git version and Nix in Requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ You can also check out the similar [dapptools-starter-kit](https://github.com/sm
 
 ## Requirements
 
--   [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+-   [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) (version 2.36.1 or above)
 -   [Foundry / Foundryup](https://github.com/gakonst/foundry)
+-   [Nix](https://nix.dev/tutorials/install-nix)
 
 And you probably already have `make` installed... but if not [try looking here.](https://askubuntu.com/questions/161104/how-do-i-install-make)
 


### PR DESCRIPTION
Changes to the Readme file:
- Added Nix as a requirement, since the Makefile runs `nix-env` in the `solc` task.
- Specified 2.36.1 as the minimum version required of git. It seems there is an issue on git versions under 2.36.1 where the `git submodule update` command, which is run by `forge update`, fails if the submodule repository doesn't have a `master` branch with this message:
```
fatal: Needed a single revision
Unable to find current origin/master revision in submodule path 'lib/chainlink-brownie-contracts'
```
The `chainlink-brownie-contracts` and `solmate` repositories don't have a `master` branch. Therefore, this error happens with git versions under 2.36.1 when running `make` or`make update`.